### PR TITLE
Use 1.2.21. Fixes Android O background service issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion '24.0.1'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.0'
 
     defaultConfig {
         applicationId 'com.twilio.client.quickstart'
         minSdkVersion 9
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -30,7 +30,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.10'
 
-    compile 'com.twilio:client-android:1.2.19'
+    compile 'com.twilio:client-android:1.2.21'
     compile 'com.android.support:appcompat-v7:24.1.1'
     compile 'com.android.support:design:24.1.1'
     compile 'com.koushikdutta.ion:ion:2.1.8'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId 'com.twilio.client.quickstart'
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -31,7 +31,7 @@ dependencies {
     testCompile 'junit:junit:4.10'
 
     compile 'com.twilio:client-android:1.2.21'
-    compile 'com.android.support:appcompat-v7:24.1.1'
-    compile 'com.android.support:design:24.1.1'
+    compile 'com.android.support:appcompat-v7:26.0.2'
+    compile 'com.android.support:design:26.0.2'
     compile 'com.koushikdutta.ion:ion:2.1.8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 


### PR DESCRIPTION
https://www.twilio.com/docs/api/client/android/changelog#1221-oct-27-2017

####  1.2.21 (Oct. 27, 2017) ####

##### Bug Fixes #####

* CLIENT-4104 Upgraded to Android Oreo from Nougat. Android CLIENT SDK runs TwilioClientService in the background. With Android 8.0 (API level 26) release, startService() method throws an IllegalStateException if an app is targeting Android 8.0. CLIENT-4104 fixes this crash.

##### Known Issues #####

* SDK versions prior to 1.2.21 will crash with an IllegalStateException when attempting to run context.startService() in the background if the app targets Android 26/Android 8.0 or above. For details on Android 8.0 behavior changes related to this issue, you can reference the section "Background execution limits" at [https://developer.android.com/about/versions/oreo/android-8.0-changes.html](https://developer.android.com/about/versions/oreo/android-8.0-changes.html).
